### PR TITLE
Update d3.stack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@ considerations of aesthetics and legibility.</p>
 
       <ul class="nobullet">
         <li><a href="https://github.com/leebyron/streamgraph" target="_blank">Processing / Java</a> &ndash; by Lee Byron</li>
-        <li><a href="https://github.com/mbostock/d3/wiki/Stack-Layout" target="_blank">D3 / JavaScript</a> &ndash; by Mike Bostock</li>
+        <li><a href="https://github.com/d3/d3-shape/blob/master/README.md#stacks" target="_blank">D3 / JavaScript</a> &ndash; by Mike Bostock</li>
       </ul>
 
     </div>


### PR DESCRIPTION
I noticed the D3 link was outdated, so thought I'd update it to point to the D3 version 4 documentation.